### PR TITLE
iotbus: Add iotdev to get events from peripheral devices

### DIFF
--- a/framework/src/iotbus/Make.defs
+++ b/framework/src/iotbus/Make.defs
@@ -17,7 +17,7 @@
 ###########################################################################
 
 ifeq ($(CONFIG_IOTBUS), y)
-CSRCS += iotapi_evt_handler.c
+CSRCS += iotapi_evt_handler.c iotapi_dev_handler.c
 
 ifeq ($(CONFIG_IOTBUS_GPIO), y)
 CSRCS += iotbus_gpio.c

--- a/framework/src/iotbus/iotapi_dev_handler.c
+++ b/framework/src/iotbus/iotapi_dev_handler.c
@@ -1,0 +1,252 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/select.h>
+#include <tinyara/iotdev.h>
+
+#include "iotapi_dev_handler.h"
+
+#define IOTAPI_CBK_QUEUE_SIZE 10
+
+#define IOT_QUEUE_LOCK											\
+	do {														\
+		pthread_mutex_lock(&g_iot_cbk_mgr.queue_lock);	\
+	} while (0)
+
+#define IOT_QUEUE_UNLOCK											\
+	do {															\
+		pthread_mutex_unlock(&g_iot_cbk_mgr.queue_lock);	\
+	} while (0)
+
+#define IOTAPI_ERROR													\
+	do {																\
+		printf("[ERR] IOTAPI %s(%d)(%s:%d)\n", __FUNCTION__, errno, __FILE__, __LINE__); \
+	} while (0)
+
+struct _iotapi_cbk_entry {
+	struct _iotapi_cbk_entry *flink;
+	struct _iotapi_dev_ctx_s *ctx;
+};
+
+struct _iotapi_cbk_queue {
+	struct _iotapi_cbk_entry *head;
+	struct _iotapi_cbk_entry *tail;
+
+	pthread_mutex_t queue_lock;
+
+	int refcnt; // debugging
+};
+
+struct _iotapi_dev_ctx_s {
+	int fd;
+	iotapi_cbk cb;
+	struct _iotapi_cbk_entry entry;
+};
+
+static int g_pfd[2] = {0,};
+
+static struct _iotapi_cbk_queue g_iot_cbk_mgr = {
+	NULL, NULL, PTHREAD_MUTEX_INITIALIZER, 0
+};
+
+static void iotapi_insert_cbk(struct _iotapi_dev_ctx_s *ctx)
+{
+	struct _iotapi_cbk_entry *node = &(ctx->entry);
+
+	node->flink = NULL;
+	struct _iotapi_cbk_queue *queue = &g_iot_cbk_mgr;
+
+	IOT_QUEUE_LOCK;
+	node->flink = NULL;
+	if (!queue->head) {
+		queue->head = node;
+		queue->tail = node;
+	} else {
+		queue->tail->flink = node;
+		queue->tail = node;
+	}
+	queue->refcnt++;
+	IOT_QUEUE_UNLOCK;
+}
+
+static void iotapi_remove_cbk(struct _iotapi_dev_ctx_s *ctx)
+{
+	struct _iotapi_cbk_queue *queue = &g_iot_cbk_mgr;
+
+	IOT_QUEUE_LOCK;
+
+	struct _iotapi_cbk_entry *node = queue->head;
+	while (node) {
+		if (node->ctx == ctx) {
+			queue->head = node->flink;
+			if (node == queue->tail) {
+				queue->tail = NULL;
+			}
+			queue->refcnt--;
+			break;
+		}
+		node = node->flink;
+	}
+
+	IOT_QUEUE_UNLOCK;
+}
+
+static void iotdev_callback(int evt)
+{
+	struct _iotapi_cbk_queue *queue = &g_iot_cbk_mgr;
+	IOT_QUEUE_LOCK;
+	struct _iotapi_cbk_entry *node = queue->head;
+	while (node) {
+		node->ctx->cb(evt);
+		node = node->flink;
+	}
+	IOT_QUEUE_UNLOCK;
+}
+
+void *iotdev_handler(void *data)
+{
+	fd_set rfds;
+	fd_set fds;
+
+	int fd = open(IOTDEV_DRVPATH, O_RDWR);
+	if (fd == -1) {
+		printf("error\n");
+		return NULL;
+	}
+	int sig = *((int *)data);
+	int max_fd = fd > sig ? (fd + 1): (sig + 1);
+
+	FD_ZERO(&fds);
+	FD_SET(fd, &fds);
+	FD_SET(sig, &fds);
+
+	while (1) {
+		rfds = fds;
+		int res = select(max_fd, &rfds, NULL, NULL, NULL);
+		if (res < 0) {
+			printf("select error\n");
+			return NULL;
+		}
+		if (FD_ISSET(sig, &rfds)) {
+			printf("terminate thread\n");
+			break;
+		}
+		if (FD_ISSET(fd, &rfds)) {
+			printf("get signal from iotdev\n");
+			char buf[5];
+			int readed = read(fd, buf, 5);
+			if (readed <= 0) {
+				printf("read error\n");
+				continue;
+			}
+
+			// call callbacks
+			iotdev_callback(1);
+		}
+	}
+	close(sig);
+	close(fd);
+
+	return NULL;
+}
+
+int iotapi_dev_init(iotapi_hnd *hnd)
+{
+	int res = pipe(g_pfd);
+	if (res == -1) {
+		IOTAPI_ERROR;
+		return -1;
+	}
+	struct _iotapi_dev_ctx_s *ctx = (struct _iotapi_dev_ctx_s *)malloc(sizeof(struct _iotapi_dev_ctx_s));
+	if (!ctx) {
+		close(g_pfd[0]);
+		close(g_pfd[1]);
+
+		return -1;
+	}
+
+	ctx->cb = NULL;
+	ctx->entry.ctx = ctx;
+	ctx->entry.flink = NULL;
+
+	pthread_t tid;
+	int ret;
+	ret = pthread_create(&tid, NULL, iotdev_handler, (void *)&g_pfd[0]);
+	if (ret < 0) {
+		printf("[iotcom] create iotapi handler fail(%d)\n", ret);
+		close(g_pfd[0]);
+		close(g_pfd[1]);
+		free(ctx);
+		return -1;
+	}
+
+	*hnd = ctx;
+
+	return 0;
+}
+
+int iotapi_dev_deinit(iotapi_hnd hnd)
+{
+	char buf[5] = "term";
+	int res = write(g_pfd[1], buf, 5);
+	if (res <= 0) {
+		printf("send term signal error(%d)(%d)\n", res, errno);
+		return -1;
+	}
+	// TBD : wait here until thread is done?
+	return 0;
+}
+
+int iotapi_dev_register(iotapi_hnd hnd, iotapi_cbk cbk)
+{
+	struct _iotapi_dev_ctx_s *ctx = (struct _iotapi_dev_ctx_s *)hnd;
+	if (!ctx) {
+		IOTAPI_ERROR;
+		return -1;
+	}
+
+	ctx->cb = cbk;
+	iotapi_insert_cbk(ctx);
+
+	return 0;
+}
+
+int iotapi_dev_unregister(iotapi_hnd hnd)
+{
+	struct _iotapi_dev_ctx_s *ctx = (struct _iotapi_dev_ctx_s *)hnd;
+	if (!ctx) {
+		IOTAPI_ERROR;
+		return -1;
+	}
+
+	iotapi_remove_cbk(ctx);
+
+	return 0;
+}

--- a/framework/src/iotbus/iotapi_dev_handler.h
+++ b/framework/src/iotbus/iotapi_dev_handler.h
@@ -1,0 +1,14 @@
+#ifndef _IOTAPI_DEV_HANDLER_H__
+#define _IOTAPI_DEV_HANDLER_H__
+
+typedef struct _iotapi_dev_ctx_s *iotapi_hnd;
+
+typedef int evttype;
+typedef void (*iotapi_cbk)(evttype evt);
+
+int iotapi_dev_init(iotapi_hnd *hnd);
+int iotapi_dev_deinit(iotapi_hnd hnd);
+int iotapi_dev_register(iotapi_hnd hnd, iotapi_cbk cbk);
+int iotapi_dev_unregister(iotapi_hnd hnd);
+
+#endif // _IOTAPI_DEV_HANDLER_H__

--- a/os/drivers/Kconfig
+++ b/os/drivers/Kconfig
@@ -486,6 +486,7 @@ config FOTA_DRIVER
 
 source drivers/syslog/Kconfig
 source drivers/ttrace/Kconfig
+source drivers/iotdev/Kconfig
 
 comment "Wireless Device Options"
 

--- a/os/drivers/Makefile
+++ b/os/drivers/Makefile
@@ -77,6 +77,7 @@ include fota$(DELIM)Make.defs
 include gpio$(DELIM)Make.defs
 include heapinfo$(DELIM)Make.defs
 include i2c$(DELIM)Make.defs
+include iotdev$(DELIM)Make.defs
 include lwnl${DELIM}Make.defs
 include net$(DELIM)Make.defs
 include pipes$(DELIM)Make.defs

--- a/os/drivers/iotdev/Kconfig
+++ b/os/drivers/iotdev/Kconfig
@@ -1,0 +1,10 @@
+#
+# For a description of the syntax of this configuration file,
+# see kconfig-language at https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt
+#
+
+config IOTDEV
+	bool "Support IoT Device"
+	default n
+	---help---
+		Handle events from peripheral devices

--- a/os/drivers/iotdev/Make.defs
+++ b/os/drivers/iotdev/Make.defs
@@ -1,0 +1,31 @@
+##########################################################################
+#
+# Copyright 2017 Samsung Electronics All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+############################################################################
+# Include kernel testcase drivers
+
+ifeq ($(CONFIG_IOTDEV),y)
+
+CSRCS += iotdev.c
+
+#CFLAGS += -I$(TOPDIR)/kernel
+
+# Include kernel testcase driver support
+
+DEPPATH += --dep-path iotdev
+VPATH += :iotdev
+
+endif

--- a/os/drivers/iotdev/iotdev.c
+++ b/os/drivers/iotdev/iotdev.c
@@ -1,0 +1,385 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <tinyara/config.h>
+#include <poll.h>
+#include <semaphore.h>
+#include <errno.h>
+#include <debug.h>
+#include <unistd.h>
+#include <tinyara/fs/fs.h>
+#include <tinyara/sched.h>
+#include <tinyara/iotdev.h>
+/* #include "clock/clock.h" */
+/* #include "signal/signal.h" */
+/* #include "timer/timer.h" */
+
+#define IOTDEV_NPOLLWAITERS 3
+
+#define IOTDEV_LOCK(priv)									\
+	do {													\
+		int iret = id_takesem(&priv->gu_exclsem);			\
+		if (iret < 0) {										\
+			lldbg("ERROR: id_takesem failed: %d\n", ret);	\
+		}													\
+	} while (0)
+
+#define IOTDEV_UNLOCK(priv)						\
+	do {										\
+		id_givesem(&priv->gu_exclsem);			\
+	} while (0)
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int id_drv_open(FAR struct file *filep);
+static int id_drv_close(FAR struct file *filep);
+static int id_drv_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup);
+static int id_drv_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+static ssize_t id_drv_read(FAR struct file *filep, FAR char *buffer, size_t len);
+static ssize_t id_drv_write(FAR struct file *filep, FAR const char *buffer, size_t len);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct file_operations id_drv_fops = {
+	id_drv_open,                                                   /* open */
+	id_drv_close,                                                   /* close */
+	id_drv_read,                                /* read */
+	id_drv_write,                               /* write */
+	0,                                                   /* seek */
+	id_drv_ioctl                                /* ioctl */
+#ifndef CONFIG_DISABLE_POLL
+	, id_drv_poll                                                  /* poll */
+#endif
+};
+
+struct id_open_s {
+
+	/* The following will be true if we are closing */
+	volatile bool io_closing;
+
+#ifndef CONFIG_DISABLE_POLL
+	/*
+	 * The following is a list if poll structures of threads waiting
+	 * for driver events
+	 */
+	FAR struct pollfd *io_fds[IOTDEV_NPOLLWAITERS];
+#endif
+};
+
+#define IOTDEV_QUEUE_SIZE 10
+
+struct id_queue {
+	int front;
+	int rear;
+	sem_t queue_lock;
+	id_evt_type queue[IOTDEV_QUEUE_SIZE];
+};
+
+
+struct id_upperhalf_s {
+	sem_t gu_exclsem;	/* Supports exclusive access to the device */
+	bool gu_sample;		/* Last sampled GPIO states */
+	struct id_queue evt_queue;
+	struct id_open_s *gu_open;
+};
+
+static struct id_open_s g_id_open;
+static struct id_upperhalf_s g_id_udev;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int _id_set_evt(struct id_queue *queue, id_evt_type evt)
+{
+	if (queue->rear == IOTDEV_QUEUE_SIZE) {
+		queue->rear = 0;
+	}
+	if (queue->rear == queue->front) {
+		// overflow!!!
+		//printf("overflow\n");
+		assert(0);
+		return -1;
+	}
+	queue->queue[queue->rear++] = evt;
+
+	return 0;
+}
+
+static int _id_get_evt(struct id_queue *queue, id_evt_type *evt)
+{
+	if (queue->front + 1 == queue->rear) {
+		// invalid request generate crash to debug it
+		// empty!!!
+		//printf("underflow\n");
+		assert(0);
+		return -1;
+	}
+	if (queue->front + 1 == IOTDEV_QUEUE_SIZE) {
+		queue->front = 0;
+		*evt = queue->queue[0];
+	} else {
+		*evt = queue->queue[++queue->front];
+	}
+
+	return 0;
+}
+
+static inline int id_takesem(FAR sem_t *sem)
+{
+	/* Take a count from the semaphore, possibly waiting */
+	if (sem_wait(sem) < 0) {
+		/* EINTR is the only error that we expect */
+		int errcode = get_errno();
+		DEBUGASSERT(errcode == EINTR);
+		return errcode;
+	}
+
+	return OK;
+}
+
+static inline void id_givesem(sem_t *sem)
+{
+	sem_post(sem);
+}
+
+int id_drv_open(FAR struct file *filep)
+{
+	// ToDo
+	return 0;
+}
+
+int id_drv_close(FAR struct file *filep)
+{
+	// ToDo
+	return 0;
+}
+
+/************************************************************************************
+ * Name: id_drv_ioctl
+ *
+ * Description:  The standard ioctl method.
+ *
+ ************************************************************************************/
+
+static int id_drv_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
+{
+	FAR struct inode *inode;
+	FAR struct id_upperhalf_s *priv;
+	FAR struct id_open_s *opriv;
+	int ret;
+	int i;
+
+	//DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+	DEBUGASSERT(filep && filep->f_inode);
+	//opriv = filep->f_priv;
+	inode = filep->f_inode;
+	DEBUGASSERT(inode->i_private);
+	priv  = (FAR struct id_upperhalf_s *)inode->i_private;
+	opriv = priv->gu_open;
+
+	/* Get exclusive access to the driver structure */
+	IOTDEV_LOCK(priv);
+
+	/* Are we setting up the poll? Or tearing it down? */
+	if (setup) {
+		/*
+		 * This is a request to set up the poll. Find an available
+		 * slot for the poll structure reference
+		 */
+		for (i = 0; i < IOTDEV_NPOLLWAITERS; i++) {
+			/* Find an available slot */
+			if (!opriv->io_fds[i]) {
+				/* Bind the poll structure and this slot */
+				opriv->io_fds[i] = fds;
+				fds->priv = &opriv->io_fds[i];
+				break;
+			}
+		}
+
+		if (i >= IOTDEV_NPOLLWAITERS) {
+			lldbg("ERROR: Too many poll waiters\n");
+			fds->priv = NULL;
+			ret       = -EBUSY;
+			goto errout_with_dusem;
+		}
+	} else if (fds->priv) {
+		/* This is a request to tear down the poll. */
+		FAR struct pollfd **slot = (FAR struct pollfd **)fds->priv;
+
+		/* Remove all memory of the poll setup */
+		*slot = NULL;
+		fds->priv = NULL;
+	}
+
+errout_with_dusem:
+	IOTDEV_UNLOCK(priv);
+	// id_givesem(&priv->gu_exclsem);
+	return ret;
+}
+
+
+
+/************************************************************************************
+ * Name: id_drv_ioctl
+ *
+ * Description:  The standard ioctl method.
+ *
+ ************************************************************************************/
+static int id_drv_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+	return 0;
+}
+
+/************************************************************************************
+ * Name: id_drv_read
+ *
+ * Description:  The standard read method.
+ *
+ ************************************************************************************/
+static ssize_t id_drv_read(FAR struct file *filep, FAR char *buffer, size_t len)
+{
+	FAR struct inode *inode;
+	FAR struct id_upperhalf_s *priv;
+//	FAR struct id_open_s *opriv;
+	int ret;
+//	int i;
+
+	//DEBUGASSERT(filep && filep->f_priv && filep->f_inode);
+	DEBUGASSERT(filep && filep->f_inode);
+	//opriv = filep->f_priv;
+	inode = filep->f_inode;
+	DEBUGASSERT(inode->i_private);
+	priv  = (FAR struct id_upperhalf_s *)inode->i_private;
+
+	IOTDEV_LOCK(priv);
+	id_evt_type evt;
+	ret = _id_get_evt(&priv->evt_queue, &evt);
+	if (ret < 0) {
+		printf("No event");
+		return -1;
+	}
+	IOTDEV_UNLOCK(priv);
+
+	if (evt == IOTD_UART1) {
+		buffer[0] = 1;
+	} else if (evt == IOTD_UART2) {
+		buffer[0] = 2;
+	}
+
+	return 1;
+}
+
+static ssize_t id_drv_write(FAR struct file *filep, FAR const char *buffer, size_t len)
+{
+	return len;                                     /* Say that everything was written */
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: id_drv_register
+ *
+ * Description:
+ *   Register /dev/testcase
+ *
+ ****************************************************************************/
+
+void id_drv_register(void)
+{
+	struct id_upperhalf_s *dev = &g_id_udev;
+
+	int i = 0;
+	for (; i < IOTDEV_NPOLLWAITERS; i++) {
+		g_id_open.io_fds[i] = NULL;
+	}
+
+	int res = sem_init(&g_id_udev.gu_exclsem, 0, 1);
+	if (res == -1) {
+		dbg("register device fail\n");
+		return;
+	}
+	g_id_udev.gu_open = &g_id_open;
+
+	// initialize evt queue
+	dev->evt_queue.front = 0;
+	dev->evt_queue.rear = 1;
+
+	(void)register_driver(IOTDEV_DRVPATH, &id_drv_fops, 0666, dev);
+}
+
+
+static void _id_trigger_evt(FAR struct id_upperhalf_s *priv, id_evt_type evt)
+{
+	FAR struct id_open_s *opriv;
+	irqstate_t flags;
+	int i;
+
+	/*
+	 * This routine is called both task level and interrupt level,
+	 * so interrupts must be disabled.
+	 */
+	flags = irqsave();
+
+	_id_set_evt(&priv->evt_queue, evt);
+
+	/* Visit each opened reference to the device */
+	opriv = priv->gu_open;
+
+	/* Have any poll events occurred? */
+	for (i = 0; i < IOTDEV_NPOLLWAITERS; i++) {
+		FAR struct pollfd *fds = opriv->io_fds[i];
+		if (fds) {
+			fds->revents |= (fds->events & POLLIN);
+			if (fds->revents != 0) {
+				sem_post(fds->sem);
+			}
+		}
+	}
+
+	irqrestore(flags);
+}
+
+/*
+ * public
+ */
+int id_post_evt(id_evt_type evt)
+{
+	struct id_upperhalf_s *dev = &g_id_udev;
+
+	if (!dev) {
+		return -1;
+	}
+
+	/* IOTDEV_LOCK(dev); */
+	/* dev->evt = evt; */
+	/* IOTDEV_UNLOCK(dev); */
+
+	_id_trigger_evt(dev, evt);
+	return 0;
+}
+

--- a/os/include/tinyara/iotdev.h
+++ b/os/include/tinyara/iotdev.h
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ * Copyright 2017 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_TINYARA_TEST_DRV_H
+#define __INCLUDE_TINYARA_TEST_DRV_H
+
+/* This file will be used to provide definitions to support
+ * kernel test case framework
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <tinyara/config.h>
+#include <tinyara/fs/ioctl.h>
+
+#ifdef CONFIG_IOTDEV
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IOTDEV_DRVPATH                       "/dev/iotdev"
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+typedef enum {
+	IOTD_UART1,
+	IOTD_UART2,
+} id_evt_type;
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C" {
+#else
+#define EXTERN extern
+#endif
+
+
+/****************************************************************************
+ * Name: id_drv_register
+ *
+ * Description:
+ *   This function creates a device node like "/dev/iotdev" which will be used
+ *   by the iotbus to get events from peripheral
+ *
+ *
+ ****************************************************************************/
+
+void id_drv_register(void);
+
+/****************************************************************************
+ * Name: id_post_evt
+ *
+ * Description:
+ *   This function creates a device node like "/dev/iotdev" which will be used
+ *   by the iotbus to get events from peripheral
+ *
+ *
+ ****************************************************************************/
+int id_post_evt(id_evt_type evt);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif							/* CONFIG_KERNEL_TEST_DRV */
+#endif							/* __INCLUDE_TINYARA_TEST_FW_H */

--- a/os/kernel/init/os_start.c
+++ b/os/kernel/init/os_start.c
@@ -530,6 +530,10 @@ void os_start(void)
 	kernel_test_drv_register();
 #endif
 
+#ifdef CONFIG_IOTDEV
+	id_drv_register();
+#endif
+
 #if defined(CONFIG_DEBUG_SYSTEM)
 	sysdbg_init();
 #endif


### PR DESCRIPTION
Add iotdev to get events from peripheral device.
Now it's impossible to get detailed events from devices in kernel becuase
it is based on poll design. so adding this api iotbus in userspace can
get events from kernel devices. to do that iotdev is registered. and
it should be handled carefully because it's designed to support 1:1
relation only. so only iotbus can access it but others should not use it.